### PR TITLE
changes needs to node support es6 and gulp version at least v4

### DIFF
--- a/bin/grunt2gulp.js
+++ b/bin/grunt2gulp.js
@@ -408,7 +408,7 @@ function gruntConverter(gruntModule) {
    */
   function printDefinition(definition) {
 
-    var value = typeof definition.value === "string" ? definition.value.replace(/\n/g,"") : definition.value;
+    var value = typeof definition.value === "string" ? definition.value.replace(/\n/g,"\\n") : definition.value;
     out("var " + definition.name + " = " + value + ";");
   }
   var converter = this;
@@ -621,7 +621,7 @@ function gruntConverter(gruntModule) {
     var needRequiredModules = [];
     for (let i = 0; i < requires.length; i += 1) {
       let [needRequire,name]= printRequire(requires[i]);
-      needRequiredModules.push(name)
+      needRequire && needRequiredModules.push(name)
     }
     out(`// npm install ${needRequiredModules.join(" ")} --save-dev`)
     out();

--- a/bin/grunt2gulp.js
+++ b/bin/grunt2gulp.js
@@ -148,7 +148,8 @@ function gruntConverter(gruntModule) {
    * @inner
    */
   function dest(str,option) {
-    pipe(`gulp.dest('${str}'${option ? ","+JSON.stringify(option):""})`);
+    let destDir = path.extname(str) ? path.dirname(str) : str;
+    pipe(`gulp.dest('${destDir}'${option ? ","+JSON.stringify(option):""})`);
   }
 
   // task-specific printers
@@ -177,7 +178,7 @@ function gruntConverter(gruntModule) {
     src(task.src)
     pipe(`uglify(${option})`);
     afterProduced && afterProduced()
-    dest(path.dirname(task.dest))
+    dest(task.dest)
     // pipe("rename({suffix: '.min'})")
   }
 
@@ -187,7 +188,7 @@ function gruntConverter(gruntModule) {
     // pipe("concat('all.js')");
     pipe(`concat('${path.basename(task.dest)}',${option})`);
     afterProduced && afterProduced()
-    dest(path.dirname(task.dest))
+    dest(task.dest)
   }
 
   taskPrinters['replace'] = function replace(task,afterProduced) {
@@ -197,14 +198,14 @@ function gruntConverter(gruntModule) {
       pipe(`replace(${pattern},${replacement})`);
     })
     afterProduced && afterProduced()
-    dest(path.dirname(task.dest))
+    dest(task.dest)
   }
   
   taskPrinters['wiredep'] = function wiredep(task,afterProduced) {
     src(task.src)
     pipe('wiredep()');
     afterProduced && afterProduced()
-    dest(path.dirname(task.dest))
+    dest(task.dest)
   }
   
   taskPrinters['filerev'] = function filerev(task,afterProduced) {
@@ -216,7 +217,7 @@ function gruntConverter(gruntModule) {
     src(task.src)
     pipe(`less(${option})`);
     afterProduced && afterProduced()
-    dest(path.dirname(task.dest))
+    dest(task.dest)
   }
 
   taskPrinters['cssmin'] = function (task,afterProduced) {
@@ -225,7 +226,7 @@ function gruntConverter(gruntModule) {
     pipe(`cssmin(${option})`);
     pipe("rename({suffix: '.min'})")
     afterProduced && afterProduced()
-    dest(path.dirname(task.dest))
+    dest(task.dest)
   }
   function prefixInBowerrc(){
     return JSON.parse(fs.readFileSync(path.resolve(".bowerrc"), 'utf-8')).hasOwnProperty("directory")
@@ -248,7 +249,7 @@ function gruntConverter(gruntModule) {
     }
     src(task.src,{cwd:srcPrefix,allowEmpty:true})
     afterProduced && afterProduced()
-    dest(path.dirname(task.dest),{
+    dest(task.dest,{
       cwd:task.options.destPrefix
     })
   }
@@ -382,7 +383,7 @@ function gruntConverter(gruntModule) {
     var value = typeof definition.value === "string" ? definition.value.replace(/\n/g,"\\n") : definition.value;
     out("var " + definition.name + " = " + value + ";");
   }
-  var converter = this;
+
   /**
    * Prints out a require statement for a gulp module. Prefixes the
    * module name with 'gulp'.
@@ -451,7 +452,7 @@ function gruntConverter(gruntModule) {
         })
         let pairsGroups = {}
         taskDestBaseNameSameAsSrc.forEach((x, index, dests) => {
-          let destDir = path.dirname(x);
+          let destDir = path.extname(x) ? path.dirname(x) : x;
           if (!pairsGroups.hasOwnProperty(destDir)) {
             pairsGroups[destDir] = []
           }
@@ -471,7 +472,7 @@ function gruntConverter(gruntModule) {
           } else {
             out("    gulp")
             src(pairsGroups[k])
-            dest(path.dirname(k))
+            dest(k)
           }
           out("    ,");
 
@@ -502,7 +503,7 @@ function gruntConverter(gruntModule) {
           } else {
             out("    gulp")
             src(task.src[index])
-            dest(path.dirname(x))
+            dest(x)
           }
 
           if (index < dests.length - 1) {

--- a/bin/grunt2gulp.js
+++ b/bin/grunt2gulp.js
@@ -467,7 +467,8 @@ function gruntConverter(gruntModule) {
           if (!pairsGroups.hasOwnProperty(destDir)){
             pairsGroups[destDir] = []
           }
-          pairsGroups[destDir].push(task.src[index])
+          let originIndex = task.dest.indexOf(x);
+          pairsGroups[destDir].push(task.src[originIndex])
         })
         // debug(pairsGroups)
         for(let k in pairsGroups){
@@ -492,23 +493,26 @@ function gruntConverter(gruntModule) {
           // }
         }
         //src and dest pairs
-        task.dest.filter( x =>  {return -1==taskDestBaseNameSameAsSrc.indexOf(x)} ).forEach( function(x,index,dests) {
+        let taskRests = task.dest.filter( x =>  {return -1==taskDestBaseNameSameAsSrc.indexOf(x)} );
+
+        taskRests.forEach( function(x,index,dests) {
           
           let 
             pluginName = task.name.split(":")[0];
 
           if (pluginName in taskPrinters) {
-            let newTask = Object.assign({},task,{src:task.src[index],dest:x})
+            let originIndex = task.dest.indexOf(x);
+            let newTask = Object.assign({},task,{src:task.src[originIndex],dest:x})
             verbose('Found task in taskPrinters: ' + task.name);
             out("    gulp")
             // src(task.src[index])
-            function afterProduced(){
+            function afterProduced(x,index,task){
               let ext = path.extname(x);
               if(ext && path.basename(x)!=path.basename(task.src[index])){
                 pipe("rename('"+ path.basename(x) +"')")
               }
             }
-            taskPrinters[pluginName](newTask,afterProduced);
+            taskPrinters[pluginName](newTask,afterProduced.bind(null,x,originIndex,task));
           } else{
             out("    gulp")
             src(task.src[index])

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jsdoc": "^3.3.0-beta1"
   },
   "dependencies": {
+    "grunt": "^1.0.2",
     "is_js": "^0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "gulp-rename": "^1.2.0",
     "gulp-uglify": "^1.0.1",
     "jsdoc": "^3.3.0-beta1"
+  },
+  "dependencies": {
+    "is_js": "^0.9.0"
   }
 }


### PR DESCRIPTION
features:
* es6 syntax
* support grunt [Files Object Format](https://gruntjs.com/configuring-tasks#files-object-format)
* Implements *bowercopy*
* support task options
* Including source code before `grunt.initConfig`
* Handle src path that using grunt template variable
* Detecting if *grunt-plugin* can change to *gulp-plugin* simply(providing npm installation suggestion in comments) otherwise will load grunt task.@todo handle loaded grunt task.
* some fixs and implements

To do list:
- [ ] Handle loaded grunt task.
- [ ] transform grunt task options to gulp task options(options schema may differents)
- [ ] grunt task and gulp task may have major differents eg. [gulp-karma](https://github.com/karma-runner/gulp-karma) that may need pre defined.
- [ ] Providing CLI arguments that ouputs generated code to a file not stdout that we can generated gulpfile.js and providing some information to console,also can easily change log level.

attachment contains grunt file of existed project and generated gulpfile.

[Archive.zip](https://github.com/rudolfolah/grunt2gulp.js/files/1895291/Archive.zip)

